### PR TITLE
EDD 3941 Shape Editor error

### DIFF
--- a/src/components/shape/ShapeEditor.vue
+++ b/src/components/shape/ShapeEditor.vue
@@ -150,6 +150,7 @@ export default {
     return {
       localShape: this.shape,
       localEditionMode: this.editionMode,
+      mapInitialized: false,
       map: null,
       points: [],
       geojson: {
@@ -223,37 +224,41 @@ export default {
     }
   },
   mounted() {
-    // Retraso simulado antes de inicializar el mapa
-    setTimeout(() => {
-    this.map = new mapboxgl.Map({
-      container: this.$refs.map,
-      style: 'mapbox://styles/mapbox/light-v10', // stylesheet location
-    });
-    this.map.on('load', () => {
-      switch (this.localEditionMode) {
-        case this.Enums.ShapeEditorEditionMode.SIMPLE:
-          if (this.mode === this.Enums.ShapeEditorMode.CREATE) {
-            this.changeToCreationMode();
-          } else {
-            this.changeToEditionMode(this.localShape);
-          }
-          break;
-        case this.Enums.ShapeEditorEditionMode.SELECT_RANGE:
-          this.changeToSelectRangeMode(this.localShape);
-          break;
-        case this.Enums.ShapeEditorEditionMode.DUPLICATE:
-          this.changeToDuplicationMode(this.localShape);
-          break;
-      }
-      this.envelope(this.map, this.projectId);
-      this.$emit('load');
-    });
-  }, 1000); // Retraso de 1 segundo
-},
+    if (this.shape) {
+      this.localShape = this.shape;
+      this.mapInitialized = true;
+      this.initializeMap();
+    }
+  },
   beforeDestroy() {
     this.map.remove();
   },
   methods: {
+    initializeMap() {
+      this.map = new mapboxgl.Map({
+      container: this.$refs.map,
+      style: 'mapbox://styles/mapbox/light-v10', // stylesheet location
+      });
+      this.map.on('load', () => {
+        switch (this.localEditionMode) {
+          case this.Enums.ShapeEditorEditionMode.SIMPLE:
+            if (this.mode === this.Enums.ShapeEditorMode.CREATE) {
+              this.changeToCreationMode();
+            } else {
+              this.changeToEditionMode(this.localShape);
+            }
+            break;
+          case this.Enums.ShapeEditorEditionMode.SELECT_RANGE:
+            this.changeToSelectRangeMode(this.localShape);
+            break;
+          case this.Enums.ShapeEditorEditionMode.DUPLICATE:
+            this.changeToDuplicationMode(this.localShape);
+            break;
+        }
+        this.envelope(this.map, this.projectId);
+        this.$emit('load');
+        });
+    },
     changeToCreationMode() {
       this.localEditionMode = this.Enums.ShapeEditorEditionMode.SIMPLE;
       this.localShape = {
@@ -970,6 +975,12 @@ export default {
   watch: {
     shape() {
       this.localShape = this.shape;
+    },
+    localShape(newValue) {
+      if (newValue && !this.mapInitialized) {
+        this.mapInitialized = true;
+        this.initializeMap();
+      }
     }
   }
 }

--- a/src/components/shape/ShapeEditor.vue
+++ b/src/components/shape/ShapeEditor.vue
@@ -223,6 +223,8 @@ export default {
     }
   },
   mounted() {
+    // Retraso simulado antes de inicializar el mapa
+    setTimeout(() => {
     this.map = new mapboxgl.Map({
       container: this.$refs.map,
       style: 'mapbox://styles/mapbox/light-v10', // stylesheet location
@@ -246,7 +248,8 @@ export default {
       this.envelope(this.map, this.projectId);
       this.$emit('load');
     });
-  },
+  }, 1000); // Retraso de 1 segundo
+},
   beforeDestroy() {
     this.map.remove();
   },


### PR DESCRIPTION
# 📚Context
The GTFS-Editor had an issue when editing the Shape of a GTFS, not displaying the points on the map.
Example:
![image](https://github.com/user-attachments/assets/fb5b4e70-7128-4342-a7b1-0a6f0f83a53a)

# 📝Changes
A watch was added to the `localShape` variable so that the map is only loaded if the point data is available.

Before:
![image](https://github.com/user-attachments/assets/294a5cde-20d3-4a7d-af24-aa334d4e800b)

After:
![image](https://github.com/user-attachments/assets/37b93ea5-0c70-4cfd-b4be-c8881d1113b8)

# 🔍Testing
To test this, change the Nginex Dockerfile of the Backend repo:
```
RUN git clone https://github.com/InspectorIncognito/gtfs-editor-frontend.git && \
    cd gtfs-editor-frontend && git checkout maintenance/EDD-3941-shape-editor-error && cd .. && \
    mv gtfs-editor-frontend/* . && \
    rm -r gtfs-editor-frontend
```
This switches the frontend branch to `maintenance/EDD-3941-shape-editor-error`, then runs `make build` and `make up` in the backend.

# 📝Pending/Future Work
N/A