### PR TITLE
SB1-170 Shape create mode error

### DIFF
--- a/src/components/shape/ShapeEditor.vue
+++ b/src/components/shape/ShapeEditor.vue
@@ -224,8 +224,6 @@ export default {
     }
   },
   mounted() {
-    // If the shape is already defined or Edition mode is "create"
-    console.log(this.shape, this.mode, this.Enums.ShapeEditorMode.CREATE);
     if (this.shape || this.mode === this.Enums.ShapeEditorMode.CREATE) {
       this.localShape = this.shape;
       this.mapInitialized = true;
@@ -983,7 +981,14 @@ export default {
         this.mapInitialized = true;
         this.initializeMap();
       }
+    },
+    mode(newMode) {
+    if (newMode === this.Enums.ShapeEditorMode.CREATE && !this.mapInitialized) {
+      this.localShape = this.shape;
+      this.mapInitialized = true;
+      this.initializeMap();
     }
+  },
   }
 }
 </script>

--- a/src/components/shape/ShapeEditor.vue
+++ b/src/components/shape/ShapeEditor.vue
@@ -225,6 +225,7 @@ export default {
   },
   mounted() {
     // If the shape is already defined or Edition mode is "create"
+    console.log(this.shape, this.mode, this.Enums.ShapeEditorMode.CREATE);
     if (this.shape || this.mode === this.Enums.ShapeEditorMode.CREATE) {
       this.localShape = this.shape;
       this.mapInitialized = true;

--- a/src/components/shape/ShapeEditor.vue
+++ b/src/components/shape/ShapeEditor.vue
@@ -224,7 +224,8 @@ export default {
     }
   },
   mounted() {
-    if (this.shape) {
+    // If the shape is already defined or Edition mode is "create"
+    if (this.shape || this.mode === this.Enums.ShapeEditorMode.CREATE) {
       this.localShape = this.shape;
       this.mapInitialized = true;
       this.initializeMap();


### PR DESCRIPTION
# 📚Context
The GTFS-Editor had an issue when create a new shape of a GTFS, not rendering the map.
Example:
![image](https://github.com/user-attachments/assets/d35163f7-bc21-48c2-a378-7a6a51422265)

# 📝Changes
A watch was added to the `mode` variable so that the map is loaded when the mode is correct.

Before:
![image](https://github.com/user-attachments/assets/9b4b6811-3dfb-4941-a1b6-1529b1587cae)

After:
![image](https://github.com/user-attachments/assets/a6c6b4c4-2e97-4e39-9825-acdb7489714f)

# 🔍Testing
To test this, change the Nginex Dockerfile of the Backend repo:
```
RUN git clone https://github.com/InspectorIncognito/gtfs-editor-frontend.git && \
    cd gtfs-editor-frontend && git checkout SB1-170-shape-create-error && cd .. && \
    mv gtfs-editor-frontend/* . && \
    rm -r gtfs-editor-frontend
```
This switches the frontend branch to `SB1-170-shape-create-error`, then runs `make rebuild` and `make up` in the backend.

# 📝Pending/Future Work
N/A


