### PR TITLE
fix(EDD-4198): Fix API endpoint URL calls

### DIFF
--- a/src/api/base.api.js
+++ b/src/api/base.api.js
@@ -7,8 +7,12 @@ const BaseAPI = class {
         this.table = table;
     }
 
-    getFullBaseURL(projectId) {
+    getBaseUrl(projectId){
         return `${this.endpoint}/${projectId}/${this.table}/`
+    }
+
+    getFullBaseURL(projectId) {
+        return `${this.client.getBaseURL()}${this.getBaseUrl(projectId)}`
     }
 
     getDetailURL(projectId, id) {
@@ -20,7 +24,7 @@ const BaseAPI = class {
     }
 
     getAll(projectId) {
-        return this.client.get(this.getFullBaseURL(projectId), {
+        return this.client.get(this.getBaseUrl(projectId), {
             params: {
                 no_page: "True"
             },
@@ -41,7 +45,7 @@ const BaseAPI = class {
     }
 
     create(projectId, data) {
-        return this.client.post(this.getFullBaseURL(projectId), data);
+        return this.client.post(this.getBaseUrl(projectId), data);
     }
 
     remove(projectId, data) {

--- a/src/api/base.api.js
+++ b/src/api/base.api.js
@@ -3,12 +3,12 @@ import httpClient from './httpClient';
 const BaseAPI = class {
     constructor(table) {
         this.client = httpClient;
-        this.endpoint = 'projects/';
+        this.endpoint = '/projects';
         this.table = table;
     }
 
     getFullBaseURL(projectId) {
-        return `${this.endpoint}${projectId}/${this.table}/`
+        return `${this.endpoint}/${projectId}/${this.table}/`
     }
 
     getDetailURL(projectId, id) {

--- a/src/api/base.api.js
+++ b/src/api/base.api.js
@@ -3,7 +3,7 @@ import httpClient from './httpClient';
 const BaseAPI = class {
     constructor(table) {
         this.client = httpClient;
-        this.endpoint = this.client.getBaseURL() + 'projects/';
+        this.endpoint = 'projects/';
         this.table = table;
     }
 

--- a/src/api/base.api.js
+++ b/src/api/base.api.js
@@ -12,7 +12,7 @@ const BaseAPI = class {
     }
 
     getDetailURL(projectId, id) {
-        return `${this.getFullBaseURL(projectId)}${id}/`
+        return `${this.endpoint}/${projectId}/${this.table}/${id}/`;
     }
 
     getFullDetailURL(projectId, id) {

--- a/src/api/base.api.js
+++ b/src/api/base.api.js
@@ -2,7 +2,7 @@ import httpClient from './httpClient';
 
 const BaseAPI = class {
     constructor(table) {
-        this.client = httpClient
+        this.client = httpClient;
         this.endpoint = this.client.getBaseURL() + 'projects/';
         this.table = table;
     }

--- a/src/api/gtfs/fareattributes.api.js
+++ b/src/api/gtfs/fareattributes.api.js
@@ -1,4 +1,4 @@
-import BaseAPI from './base.api';
+import BaseAPI from '../base.api';
 
 const fareAttributesAPI = new BaseAPI.BaseAPI('fareattributes');
 

--- a/src/api/gtfs/levels.api.js
+++ b/src/api/gtfs/levels.api.js
@@ -1,4 +1,4 @@
-import BaseAPI from './base.api';
+import BaseAPI from '../base.api';
 
 const levelsAPI = new BaseAPI.BaseAPI('levels');
 

--- a/src/api/gtfs/pathways.api.js
+++ b/src/api/gtfs/pathways.api.js
@@ -1,4 +1,4 @@
-import BaseAPI from './base.api';
+import BaseAPI from '../base.api';
 
 const pathwaysAPI = new BaseAPI.BaseAPI('pathways');
 

--- a/src/api/gtfs/transfers.api.js
+++ b/src/api/gtfs/transfers.api.js
@@ -1,4 +1,4 @@
-import BaseAPI from './base.api';
+import BaseAPI from '../base.api';
 
 const transfersAPI = new BaseAPI.BaseAPI('transfers');
 

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -2,10 +2,9 @@ import axios from 'axios';
 import store from "@/store";
 
 const baseUrl = process.env.VUE_APP_BASE_URL ? process.env.VUE_APP_BASE_URL : '';
-const apiEndpoint = 'api/';
 
 const httpClient = axios.create({
-    baseURL: `${baseUrl}/${apiEndpoint}`,
+    baseURL: `${baseUrl}/`,
     timeout: 5000, // indicates, 1000ms i.e. 1 second
     headers: {
         "Content-Type": "application/json"
@@ -13,7 +12,7 @@ const httpClient = axios.create({
 });
 
 httpClient.getBaseURL = () => {
-    return `${baseUrl}/${apiEndpoint}`;
+    return `${baseUrl}/`;
 }
 
 // interceptor to catch errors

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import store from "@/store";
 
 const baseUrl = process.env.VUE_APP_BASE_URL ? process.env.VUE_APP_BASE_URL : '';
-const apiEndpoint = 'api/';
+const apiEndpoint = 'api';
 
 const httpClient = axios.create({
     baseURL: `${baseUrl}/${apiEndpoint}`,

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -2,9 +2,10 @@ import axios from 'axios';
 import store from "@/store";
 
 const baseUrl = process.env.VUE_APP_BASE_URL ? process.env.VUE_APP_BASE_URL : '';
+const apiEndpoint = 'api/';
 
 const httpClient = axios.create({
-    baseURL: `${baseUrl}/`,
+    baseURL: `${baseUrl}/${apiEndpoint}`,
     timeout: 5000, // indicates, 1000ms i.e. 1 second
     headers: {
         "Content-Type": "application/json"
@@ -12,7 +13,7 @@ const httpClient = axios.create({
 });
 
 httpClient.getBaseURL = () => {
-    return `${baseUrl}/`;
+    return `${baseUrl}/${apiEndpoint}`;
 }
 
 // interceptor to catch errors

--- a/src/api/tables.api.js
+++ b/src/api/tables.api.js
@@ -1,9 +1,9 @@
 import httpClient from './httpClient';
 
-const END_POINT = 'projects/'
+const END_POINT = '/projects'
 
 const list_tables = (projectId) => {
-    let url = `${END_POINT}${projectId}/tables/`;
+    let url = `${END_POINT}/${projectId}/tables/`;
     return httpClient.get(url);
 };
 

--- a/src/components/InteractiveMap.vue
+++ b/src/components/InteractiveMap.vue
@@ -142,7 +142,7 @@ export default {
           nullable: true,
           id_field: 'shape',
           ajax_params: {
-            url: shapesAPI.shapesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: shapesAPI.shapesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },

--- a/src/mixins/stopsMixin.js
+++ b/src/mixins/stopsMixin.js
@@ -1,5 +1,5 @@
 import stopsAPI from '@/api/gtfs/stops.api';
-import levelsAPI from '@/api/levels.api';
+import levelsAPI from '@/api/gtfs/levels.api';
 import Enums from "@/utils/enums";
 
 let stopsMixin = {

--- a/src/mixins/stopsMixin.js
+++ b/src/mixins/stopsMixin.js
@@ -72,7 +72,7 @@ let stopsMixin = {
           fk_name: 'stop_id',
           nullable: true,
           ajax_params: {
-            url: stopsAPI.stopsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: stopsAPI.stopsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },
@@ -104,7 +104,7 @@ let stopsMixin = {
           id_field: 'level',
           nullable: true,
           ajax_params: {
-            url: levelsAPI.levelsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: levelsAPI.levelsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },

--- a/src/views/FareAttributesView.vue
+++ b/src/views/FareAttributesView.vue
@@ -82,7 +82,7 @@ export default {
           foreignKey: true,
           id_field: 'agency',
           ajax_params: {
-            url: agenciesAPI.agenciesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: agenciesAPI.agenciesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT,
         },

--- a/src/views/FareAttributesView.vue
+++ b/src/views/FareAttributesView.vue
@@ -11,7 +11,7 @@
 
 <script>
 import EditableTable from "@/components/vuetable/EditableTable.vue";
-import fareAttributesAPI from '@/api/fareattributes.api';
+import fareAttributesAPI from '@/api/gtfs/fareattributes.api';
 import agenciesAPI from '@/api/gtfs/agencies.api';
 import TableHeader from "@/components/vuetable/TableHeader";
 import Enums from "@/utils/enums";

--- a/src/views/FareRulesView.vue
+++ b/src/views/FareRulesView.vue
@@ -41,7 +41,7 @@ export default {
           id_field: 'fare_attribute',
           required: true,
           ajax_params: {
-            url: fareAttributesAPI.fareAttributesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: fareAttributesAPI.fareAttributesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT,
         },
@@ -53,7 +53,7 @@ export default {
           nullable: true,
           id_field: 'route',
           ajax_params: {
-            url: routesAPI.routesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: routesAPI.routesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT,
         },

--- a/src/views/FareRulesView.vue
+++ b/src/views/FareRulesView.vue
@@ -12,7 +12,7 @@
 <script>
 import EditableTable from "@/components/vuetable/EditableTable.vue";
 import fareRulesAPI from '@/api/gtfs/farerules.api';
-import fareAttributesAPI from '@/api/fareattributes.api';
+import fareAttributesAPI from '@/api/gtfs/fareattributes.api';
 import routesAPI from '@/api/gtfs/routes.api';
 import TableHeader from "@/components/vuetable/TableHeader";
 import Enums from "@/utils/enums";

--- a/src/views/FrequencyView.vue
+++ b/src/views/FrequencyView.vue
@@ -40,7 +40,7 @@ export default {
           foreignKey: true,
           id_field: 'trip',
           ajax_params: {
-            url: tripsAPI.tripsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: tripsAPI.tripsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },

--- a/src/views/LevelsView.vue
+++ b/src/views/LevelsView.vue
@@ -11,7 +11,7 @@
 
 <script>
 import EditableTable from "@/components/vuetable/EditableTable.vue";
-import levelsAPI from '@/api/levels.api';
+import levelsAPI from '@/api/gtfs/levels.api';
 import TableHeader from "@/components/vuetable/TableHeader";
 import Enums from "@/utils/enums";
 

--- a/src/views/PathwaysView.vue
+++ b/src/views/PathwaysView.vue
@@ -11,7 +11,7 @@
 
 <script>
 import EditableTable from "@/components/vuetable/EditableTable.vue";
-import pathwaysAPI from '@/api/pathways.api';
+import pathwaysAPI from '@/api/gtfs/pathways.api';
 import stopsAPI from '@/api/gtfs/stops.api'
 import TableHeader from "@/components/vuetable/TableHeader";
 import Enums from "@/utils/enums";

--- a/src/views/PathwaysView.vue
+++ b/src/views/PathwaysView.vue
@@ -62,7 +62,7 @@ export default {
           id_field: 'from_stop',
           required: true,
           ajax_params: {
-            url: stopsAPI.stopsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: stopsAPI.stopsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },
@@ -75,7 +75,7 @@ export default {
           id_field: 'to_stop',
           required: true,
           ajax_params: {
-            url: stopsAPI.stopsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: stopsAPI.stopsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },

--- a/src/views/RoutesView.vue
+++ b/src/views/RoutesView.vue
@@ -52,7 +52,7 @@ export default {
           id_field: 'agency',
           required: true,
           ajax_params: {
-            url: agenciesAPI.agenciesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: agenciesAPI.agenciesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },

--- a/src/views/TransfersView.vue
+++ b/src/views/TransfersView.vue
@@ -53,7 +53,7 @@ export default {
           id_field: 'from_stop',
           required: true,
           ajax_params: {
-            url: stopsAPI.stopsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: stopsAPI.stopsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },
@@ -66,7 +66,7 @@ export default {
           id_field: 'to_stop',
           required: true,
           ajax_params: {
-            url: stopsAPI.stopsAPI.getFullBaseURL(this.$route.params.projectId),
+            url: stopsAPI.stopsAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },

--- a/src/views/TransfersView.vue
+++ b/src/views/TransfersView.vue
@@ -11,7 +11,7 @@
 
 <script>
 import EditableTable from "@/components/vuetable/EditableTable.vue";
-import transfersAPI from '@/api/transfers.api';
+import transfersAPI from '@/api/gtfs/transfers.api';
 import stopsAPI from '@/api/gtfs/stops.api'
 import TableHeader from "@/components/vuetable/TableHeader";
 import Enums from "@/utils/enums";

--- a/src/views/TripsView.vue
+++ b/src/views/TripsView.vue
@@ -54,7 +54,7 @@ export default {
           id_field: 'route',
           required: true,
           ajax_params: {
-            url: routesAPI.routesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: routesAPI.routesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },
@@ -66,7 +66,7 @@ export default {
           nullable: true,
           id_field: 'shape',
           ajax_params: {
-            url: shapesAPI.shapesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: shapesAPI.shapesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },
@@ -76,7 +76,7 @@ export default {
           foreignKey: true,
           id_field: 'service_id',
           ajax_params: {
-            url: servicesAPI.servicesAPI.getFullBaseURL(this.$route.params.projectId),
+            url: servicesAPI.servicesAPI.getBaseUrl(this.$route.params.projectId),
           },
           type: Enums.InputType.FK_SELECT
         },


### PR DESCRIPTION
# 📚Context
Continuation of #9. After doing the Cypress testing, some endpoint calls failed. Specifically, the foreign keys from gtfs data. (e.g. when selecting the related service of a trip).


# 📝Changes
- Modified httpClient method getFullBaseURL
- Added httpClient method getBaseURL

# 🔍Testing
N/A

# 📝Pending/Future Work
Stop Times tests couldn't be done because of Cypress limitations with selecting data from the map.