### PR TITLE
fix(EDD-4596): fix gtfs reload issue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,9 +68,9 @@ export default {
       });
     }
   },
-  mounted() {
+  created() {
     this.$store.dispatch('auth/autologin');
     this.$store.dispatch('lang/loadLanguage', this.$i18n);
   }
 }
-</script>>
+</script>


### PR DESCRIPTION
# 📚 Contexto

Antes, al hacer reload de la aplicación, la información desaparecía.
Esto pasaba porque la inicialización (auth/autologin) ocurría en el hook `mounted`, es decir, después de que el componente ya había sido renderizado.

Con este cambio, ahora se ejecuta en el hook `created`, lo que asegura que los datos del store estén listos antes de renderizar.

# 📝 Cambios

<!-- Detalla los cambios específicos realizados en este PR. Puedes organizarlos por capas para mayor claridad. -->
- Se movió la inicialización de `auth/autologin` y `lang/loadLanguage` del hook `mounted` al hook `created` en `App.vue.`

# 🔍 Qué probar
- [ ] Hacer reload en la aplicación y comprobar que la información del usuario logueado se mantiene visible.

<!-- # 📌 Pendiente -->
<!-- Puedes incluir elementos adicionales en la lista de verificación que los colaboradores deben completar antes de que este PR pueda considerarse listo. -->


